### PR TITLE
Kernel interface update

### DIFF
--- a/ch34x.c
+++ b/ch34x.c
@@ -1351,3 +1351,4 @@ static void __exit ch34x_exit(void)
 
 module_init( ch34x_init );
 module_exit( ch34x_exit );
+

--- a/ch34x.c
+++ b/ch34x.c
@@ -1351,4 +1351,3 @@ static void __exit ch34x_exit(void)
 
 module_init( ch34x_init );
 module_exit( ch34x_exit );
-

--- a/ch34x.c
+++ b/ch34x.c
@@ -113,7 +113,7 @@ do{									\
 do{								\
 	if(0)						\
 	printk( KERN_ERR KBUILD_MODNAME ": " format "\n", ##arg)\
-}while(0)						
+}while(0)
 #endif
 
 // For debug
@@ -172,13 +172,13 @@ static struct ch34x_buf *ch34x_buf_alloc( unsigned int size )
 		return NULL;
 
 	pb = kmalloc( sizeof(struct ch34x_buf), GFP_KERNEL );
-    
+
 	if( pb == NULL )
 		return NULL;
 
 	pb->buf_buf = kmalloc( size, GFP_KERNEL );
-    
-	if( pb->buf_buf == NULL ) 
+
+	if( pb->buf_buf == NULL )
     {
 		kfree(pb);
 		return NULL;
@@ -204,7 +204,7 @@ static void ch34x_buf_free( struct ch34x_buf *pb )
 // Clear out all data in the circular buffer
 static void ch34x_buf_clear( struct ch34x_buf *pb )
 {
-	if( pb != NULL ) 
+	if( pb != NULL )
 		pb->buf_get = pb->buf_put;
 	// equivalent to a get of all data available
 }
@@ -242,19 +242,19 @@ static unsigned int ch34x_buf_put( struct ch34x_buf *pb,
 		return 0;
 
 	len = ch34x_buf_space_avail(pb);
-    
+
 	if( count > len ) count = len;
 	else if( count == 0 ) return 0;
 
 	len = pb->buf_buf + pb->buf_size - pb->buf_put;
-    
-	if( count > len ) 
+
+	if( count > len )
     {
 		memcpy( pb->buf_put, buf, len );
 		memcpy( pb->buf_buf, buf+len, count - len );
 		pb->buf_put = pb->buf_buf + count - len;
 	}
-	else 
+	else
     {
 		memcpy( pb->buf_put, buf, count );
 		if( count < len )
@@ -281,14 +281,14 @@ static unsigned int ch34x_buf_get( struct ch34x_buf *pb,
 		return 0;
 
 	len = pb->buf_buf + pb->buf_size - pb->buf_get;
-    
-	if( count > len ) 
+
+	if( count > len )
     {
 		memcpy( buf, pb->buf_get, len );
 		memcpy( buf+len, pb->buf_buf, count - len );
 		pb->buf_get = pb->buf_buf + count - len;
 	}
-	else 
+	else
     {
 		memcpy( buf, pb->buf_get, count );
 		if( count < len )
@@ -309,9 +309,9 @@ static int ch34x_vendor_read( __u8 request,
 {
 	int retval;
 
-	retval = usb_control_msg( serial->dev, usb_rcvctrlpipe(serial->dev, 0), 
+	retval = usb_control_msg( serial->dev, usb_rcvctrlpipe(serial->dev, 0),
 			request, VENDOR_READ_TYPE, value, index, buf, len, 1000 );
-	dbg_ch34x("0x%x:0x%x:0x%x:0x%x %d - %d", 
+	dbg_ch34x("0x%x:0x%x:0x%x:0x%x %d - %d",
 			VENDOR_READ_TYPE, request, value, index, retval, len );
 
 	return retval;
@@ -326,7 +326,7 @@ static int ch34x_vendor_write( __u8 request,
 {
 	int retval;
 
-	retval = usb_control_msg( serial->dev, 
+	retval = usb_control_msg( serial->dev,
 			usb_sndctrlpipe(serial->dev, 0),
 			request,
 			VENDOR_WRITE_TYPE,
@@ -340,7 +340,7 @@ static int set_control_lines( struct usb_serial *serial,
 {
 	int retval;
 
-	retval = ch34x_vendor_write( VENDOR_MODEM_OUT, (unsigned short)value, 
+	retval = ch34x_vendor_write( VENDOR_MODEM_OUT, (unsigned short)value,
 			0x0000, serial, NULL, 0x00 );
 	dbg_ch34x("%s - value=%d, retval=%d", __func__, value, retval );
 
@@ -354,22 +354,22 @@ static int ch34x_get_baud_rate( unsigned int baud_rate,
 	unsigned char b;
 	unsigned long c;
 
-	switch ( baud_rate ) 
+	switch ( baud_rate )
     {
 	case 921600:
-        
+
 		a = 0xf3;
 		b = 7;
 		break;
-        
+
 	case 307200:
-        
+
 		a = 0xd9;
 		b = 7;
 		break;
-        
+
 	default:
-        
+
 		if ( baud_rate > 6000000/255 ) {
 			b = 3;
 			c = 6000000;
@@ -383,7 +383,7 @@ static int ch34x_get_baud_rate( unsigned int baud_rate,
 			b = 0;
 			c = 11719;
 		}
-		
+
 		a = (unsigned char)(c / baud_rate);
 		if (a == 0 || a == 0xFF) return -EINVAL;
 		if ((c / a - baud_rate) > (baud_rate - c / (a + 1)))
@@ -391,7 +391,7 @@ static int ch34x_get_baud_rate( unsigned int baud_rate,
 		a = 256 - a;
 		break;
 	}
-	
+
 	*factor = a;
 	*divisor = b;
 	return 0;
@@ -407,16 +407,16 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 {
 	struct tty_struct *tty = port->tty;
 #endif
-    
-	struct usb_serial *serial = port->serial;	
+
+	struct usb_serial *serial = port->serial;
 	struct ch34x_private *priv = usb_get_serial_port_data(port);
-    
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,1)) 
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,1))
 	struct ktermios *termios = &tty->termios;
 #else
 	struct ktermios *termios = tty->termios;
 #endif
-    
+
 	unsigned int baud_rate;
 	unsigned int cflag;
 	unsigned long flags;
@@ -428,13 +428,13 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 	unsigned char reg_value = 0;
 	unsigned short value = 0;
 	unsigned short index = 0;
-    
+
 #if(LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0))
 	dbg_ch34x("%s - port:%d", __func__, port->number);
 #else
 	dbg_ch34x("%s - port:%d", __func__, port->port_number);
 #endif
-	
+
 	spin_lock_irqsave( &priv->lock, flags );
 	if( !priv->termios_initialized ) {
 		*(termios) = tty_std_termios;
@@ -447,7 +447,7 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 
 	/*
 	 * The ch34x is reported to lose bytes if you change serial setting
-	 * even to the same vaules as before. Thus we actually need to filter 
+	 * even to the same vaules as before. Thus we actually need to filter
 	 * in this specific case.
 	 */
 	if( !tty_termios_hw_change(termios, old_termios) )
@@ -480,12 +480,12 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 	}
 	dbg_ch34x("%s - data bits = %d", __func__, reg_value + 0x05 );
 
-	// Figure out the stop bits 
+	// Figure out the stop bits
 	if( cflag & CSTOPB ) {
 		reg_value |= 0x04;
 		dbg_ch34x("%s - stop bits = 2", __func__);
 	}
-	else 
+	else
 		dbg_ch34x("%s - stop bits = 1", __func__);
 
 	// Determine the parity
@@ -513,10 +513,10 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 
 	// Determine the baud rate
 	baud_rate = tty_get_baud_rate( tty );
-	dbg_ch34x("%s = baud_rate = %d", __func__, baud_rate);	
-	ch34x_get_baud_rate( baud_rate, &factor, &divisor );	
+	dbg_ch34x("%s = baud_rate = %d", __func__, baud_rate);
+	ch34x_get_baud_rate( baud_rate, &factor, &divisor );
 	dbg_ch34x("----->>>> baud_rate = %d, factor:0x%x, divisor:0x%x",
-				baud_rate, factor, divisor );	
+				baud_rate, factor, divisor );
 
 	//enable SFR_UART RX and TX
 	reg_value |= 0xc0;
@@ -530,7 +530,7 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 	ch34x_vendor_write( VENDOR_SERIAL_INIT, value, index, serial, NULL, 0 );
 
 	// change control lines if we are switching to or from B0
-	spin_lock_irqsave( &priv->lock, flags ); 
+	spin_lock_irqsave( &priv->lock, flags );
 	control = priv->line_control;
 	if( (cflag & CBAUD) == B0 )
 		priv->line_control &= ~(CONTROL_DTR | CONTROL_RTS);
@@ -554,7 +554,7 @@ static void ch34x_set_termios( struct usb_serial_port *port,
 
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,3)) 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,3))
 static int ch34x_tiocmget( struct tty_struct *tty )
 {
 	struct usb_serial_port *port = tty->driver_data;
@@ -578,7 +578,7 @@ static int ch34x_tiocmget( struct usb_serial_port *port,
 #else
 	dbg_ch34x("%s - port:%d", __func__, port->port_number);
 #endif
-	if( !usb_get_intfdata( port->serial->interface) ) 
+	if( !usb_get_intfdata( port->serial->interface) )
 		return -ENODEV;
 
 	spin_lock_irqsave( &priv->lock, flags );
@@ -607,7 +607,7 @@ static void ch34x_close( struct usb_serial_port *port )
 {
 	struct tty_struct *tty = port->port.tty;
 #elif (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27))
-static void ch34x_close( struct usb_serial_port *port, 
+static void ch34x_close( struct usb_serial_port *port,
 		struct file *filp )
 {
 
@@ -634,7 +634,7 @@ static void ch34x_close( struct usb_serial_port *port,
 	usb_kill_urb(port->write_urb);
 
 	if( tty ) {
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,1)) 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,1))
 		c_cflag = tty->termios.c_cflag;
 #else
 		c_cflag = tty->termios->c_cflag;
@@ -649,7 +649,7 @@ static void ch34x_close( struct usb_serial_port *port,
 	}
 }
 
-// kernel version 
+// kernel version
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32) \
 		&& LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
 static int ch34x_open( struct tty_struct *tty,
@@ -685,11 +685,11 @@ static int ch34x_open( struct usb_serial_port *port,
 #endif
 	}
 
-	dbg_ch34x("%s - submit read urb", __func__); 
-	port->read_urb->dev = serial->dev; 
+	dbg_ch34x("%s - submit read urb", __func__);
+	port->read_urb->dev = serial->dev;
 	retval = usb_submit_urb( port->read_urb, GFP_KERNEL );
 	if(retval) {
-		dev_err( &port->dev, "%s - failed submit read urb,error %d\n", 
+		dev_err( &port->dev, "%s - failed submit read urb,error %d\n",
 				__func__, retval );
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32) && \
 		LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) )
@@ -703,10 +703,10 @@ static int ch34x_open( struct usb_serial_port *port,
 	}
 
 	dbg_ch34x("%s - submit interrupt urb", __func__ );
-	port->interrupt_in_urb->dev = serial->dev; 
+	port->interrupt_in_urb->dev = serial->dev;
 	retval = usb_submit_urb( port->interrupt_in_urb, GFP_KERNEL );
 	if(retval) {
-		dev_err( &port->dev, "%s - failed submit interrupt urb,error %d\n", 
+		dev_err( &port->dev, "%s - failed submit interrupt urb,error %d\n",
 				__func__, retval );
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,32) && \
 		LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27) )
@@ -749,7 +749,7 @@ static int ch34x_tiocmset( struct usb_serial_port *port,
 	dbg_ch34x("%s - port:%d", __func__, port->port_number);
 #endif
 
-	if( !usb_get_intfdata(port->serial->interface) ) 
+	if( !usb_get_intfdata(port->serial->interface) )
 		return -ENODEV;
 
 	spin_lock_irqsave( &priv->lock, flags );
@@ -789,7 +789,7 @@ static int wait_modem_info( struct usb_serial_port *port,
 		wait_event_interruptible( wq, wait_flag != 0 );
 		wait_flag = 0;
 		// see if a signal did it
-		if( signal_pending(current) ) 
+		if( signal_pending(current) )
 			return -ERESTARTSYS;
 
 		spin_lock_irqsave( &priv->lock, flags );
@@ -811,13 +811,13 @@ static int wait_modem_info( struct usb_serial_port *port,
 	return 0;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,3)) 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,3))
 static int ch34x_ioctl( struct tty_struct *tty,
 		unsigned int cmd, unsigned long arg )
 {
 	struct usb_serial_port *port = tty->driver_data;
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-static int ch34x_ioctl( struct tty_struct *tty, 
+static int ch34x_ioctl( struct tty_struct *tty,
 		struct file *filp, unsigned int cmd, unsigned long arg )
 {
 	struct usb_serial_port *port = tty->driver_data;
@@ -834,7 +834,7 @@ static int ch34x_ioctl( struct usb_serial_port *port,
 #endif
 	switch(cmd)
 	{
-		// Note here 
+		// Note here
 		case TIOCMIWAIT:
 #if(LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0))
 			dbg_ch34x("%s - port:%d TIOCMIWAIT", __func__, port->number);
@@ -897,11 +897,11 @@ static void ch34x_send( struct usb_serial_port *port )
 		// reschedule ch34x_send
 	}
 
-	usb_serial_port_softint( port ); 
+	usb_serial_port_softint( port );
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-static int ch34x_write( struct tty_struct *tty, 
+static int ch34x_write( struct tty_struct *tty,
 		struct usb_serial_port *port, const unsigned char *buf, int count )
 #else
 static int ch34x_write( struct usb_serial_port *port,
@@ -921,7 +921,7 @@ static int ch34x_write( struct usb_serial_port *port,
 		return count;
 
 	spin_lock_irqsave( &priv->lock, flags );
-	count = ch34x_buf_put( priv->buf, buf, count ); 
+	count = ch34x_buf_put( priv->buf, buf, count );
 	spin_unlock_irqrestore( &priv->lock, flags );
 
 	ch34x_send(port);
@@ -930,15 +930,15 @@ static int ch34x_write( struct usb_serial_port *port,
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-static int ch34x_write_room( struct tty_struct *tty )
+static unsigned int ch34x_write_room( struct tty_struct *tty )
 {
 	struct usb_serial_port *port = tty->driver_data;
 #else
-static int ch34x_write_room( struct usb_serial_port *port )
+static unsigned int ch34x_write_room( struct usb_serial_port *port )
 {
 #endif
 	struct ch34x_private *priv = usb_get_serial_port_data( port );
-	int room = 0;
+	unsigned int room = 0;
 	unsigned long flags;
 
 #if(LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0))
@@ -951,20 +951,20 @@ static int ch34x_write_room( struct usb_serial_port *port )
 	room = ch34x_buf_space_avail( priv->buf );
 	spin_unlock_irqrestore( &priv->lock, flags );
 
-	dbg_ch34x("%s - room:%d", __func__, room );
+	dbg_ch34x("%s - room:%u", __func__, room );
 	return room;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-static int ch34x_chars_in_buffer( struct tty_struct *tty )
+static unsigned int ch34x_chars_in_buffer( struct tty_struct *tty )
 {
 	struct usb_serial_port *port = tty->driver_data;
 #else
-static int ch34x_chars_in_buffer( struct usb_serial_port *port )
+static unsigned int ch34x_chars_in_buffer( struct usb_serial_port *port )
 {
 #endif
 	struct ch34x_private *priv = usb_get_serial_port_data(port);
-	int chars = 0;
+	unsigned int chars = 0;
 	unsigned long flags;
 
 #if(LINUX_VERSION_CODE < KERNEL_VERSION(3, 11, 0))
@@ -977,14 +977,14 @@ static int ch34x_chars_in_buffer( struct usb_serial_port *port )
 	chars = ch34x_buf_data_avail( priv->buf );
 	spin_unlock_irqrestore( &priv->lock, flags );
 
-	dbg_ch34x("%s - chars:%d", __func__, chars );
+	dbg_ch34x("%s - chars:%u", __func__, chars );
 
 	return chars;
 }
 
 static int ch34x_attach( struct usb_serial *serial )
 {
-	struct ch34x_private *priv; 
+	struct ch34x_private *priv;
 	int i;
 	char buf[8];
 
@@ -1008,7 +1008,7 @@ static int ch34x_attach( struct usb_serial *serial )
 			serial, buf, 0x02 );
 	ch34x_vendor_write( VENDOR_SERIAL_INIT, 0x0000, 0x0000,
 			serial, NULL, 0x00 );
-	ch34x_vendor_write( VENDOR_WRITE, 0x1312, 0xD982, 
+	ch34x_vendor_write( VENDOR_WRITE, 0x1312, 0xD982,
 			serial, NULL, 0x00 );
 	ch34x_vendor_write( VENDOR_WRITE, 0x0F2C, 0x0004,
 			serial, NULL, 0x00 );
@@ -1072,7 +1072,7 @@ static void ch34x_update_line_status( struct usb_serial_port *port,
 
 static void ch34x_read_int_callback( struct urb *urb )
 {
-	struct usb_serial_port *port = (struct usb_serial_port *)urb->context; 
+	struct usb_serial_port *port = (struct usb_serial_port *)urb->context;
 	unsigned char *data = urb->transfer_buffer;
 	unsigned int actual_length = urb->actual_length;
 	int status = urb->status;
@@ -1100,16 +1100,16 @@ static void ch34x_read_int_callback( struct urb *urb )
 	usb_serial_debug_data( &port->dev, __func__,
 			urb->actual_length, urb->transfer_buffer );
 #else
-	usb_serial_debug_data( debug, &port->dev, 
+	usb_serial_debug_data( debug, &port->dev,
 			__func__, urb->actual_length, urb->transfer_buffer );
 #endif
 
 	ch34x_update_line_status( port, data, actual_length );
 
 exit:
-	retval = usb_submit_urb( urb, GFP_ATOMIC ); 
-	if( retval ) 
-		dev_err( &urb->dev->dev, "%s - usb_submit_urb failed with result %d\n", 
+	retval = usb_submit_urb( urb, GFP_ATOMIC );
+	if( retval )
+		dev_err( &urb->dev->dev, "%s - usb_submit_urb failed with result %d\n",
 				__func__, retval );
 }
 
@@ -1139,7 +1139,7 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 			urb->dev = port->serial->dev;
 			retval = usb_submit_urb( urb, GFP_ATOMIC );
 			if( retval ) {
-				dev_err( &urb->dev->dev, 
+				dev_err( &urb->dev->dev,
 						"%s - failed resubmitting read urb, error %d\n",
 						__func__, retval );
 				return;
@@ -1154,7 +1154,7 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 	usb_serial_debug_data( &port->dev, __func__,
 			urb->actual_length, data );
 #else
-	usb_serial_debug_data( debug, &port->dev, 
+	usb_serial_debug_data( debug, &port->dev,
 			__func__, urb->actual_length, data );
 #endif
 
@@ -1165,10 +1165,10 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 	line_status = priv->line_status;
 	priv->line_status &= ~UART_STATE_TRANSIENT_MASK;
 	spin_unlock_irqrestore( &priv->lock, flags );
-	wait_flag = 1;  
+	wait_flag = 1;
 	wake_up_interruptible( &priv->delta_msr_wait );
 
-	// break takes precedence over parity, 
+	// break takes precedence over parity,
 	// which takes precedence over framing errors
 	if( line_status & UART_PARITY_ERROR )
 		tty_flag = TTY_PARITY;
@@ -1179,7 +1179,7 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 	dbg_ch34x("%s - tty_flag=%d", __func__, tty_flag);
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
-	tty = port->port.tty; 
+	tty = port->port.tty;
 #else
 	tty = port->tty;
 #endif
@@ -1193,8 +1193,8 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 		if( line_status & UART_OVERRUN_ERROR )
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,1))
 			tty_insert_flip_char( tty->port, 0, TTY_OVERRUN );
-#else 
-			tty_insert_flip_char( tty, 0, TTY_OVERRUN ); 
+#else
+			tty_insert_flip_char( tty, 0, TTY_OVERRUN );
 #endif
 		for( i = 0; i < urb->actual_length; ++i )
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,9,1))
@@ -1212,14 +1212,14 @@ static void ch34x_read_bulk_callback( struct urb *urb )
 
 	//Schedule the next read _if_ we are still open
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2,6,27))
-	if( port->open_count ) 
+	if( port->open_count )
 #endif
 	{
 		urb->dev = port->serial->dev;
 		retval = usb_submit_urb( urb, GFP_ATOMIC );
-		if( retval ) 
-			dev_err( &urb->dev->dev, 
-					"%s - fialed resubmitting read urb, error %d\n", 
+		if( retval )
+			dev_err( &urb->dev->dev,
+					"%s - fialed resubmitting read urb, error %d\n",
 					__func__, retval );
 	}
 
@@ -1256,10 +1256,10 @@ static void ch34x_write_bulk_callback( struct urb *urb )
 			port->write_urb->dev = port->serial->dev;
 			retval = usb_submit_urb(port->write_urb, GFP_ATOMIC);
 			if( retval )
-				dev_err( &urb->dev->dev, 
+				dev_err( &urb->dev->dev,
 						"%s - failed resubmitting write urv, error:%d\n",
 						__func__, retval );
-			else 
+			else
 				return;
 	}
 
@@ -1297,7 +1297,7 @@ static struct usb_serial_driver	ch34x_device = {
 #endif
 };
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,5)) 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,5))
 static struct usb_serial_driver *const serial_driver [] = {
 	&ch34x_device, NULL
 };
@@ -1306,7 +1306,7 @@ static struct usb_serial_driver *const serial_driver [] = {
 
 static int __init ch34x_init(void)
 {
-#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,4,5)) 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,4,5))
 	int retval = 0;
 
 	retval = usb_serial_register( &ch34x_device );
@@ -1328,7 +1328,7 @@ err_usb_serial_register:
 	usb_serial_deregister( &ch34x_device );
 	return retval;
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,1))
-	return usb_serial_register_drivers( serial_driver, 
+	return usb_serial_register_drivers( serial_driver,
 			KBUILD_MODNAME, id_table );
 #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(3,4,5) && \
 		LINUX_VERSION_CODE < KERNEL_VERSION(3,5,1))


### PR DESCRIPTION
It seems that the kernel interface has been updated for these two elements in the struct usb_serial_struct:
`	.write_room     = ch34x_write_room,
	.chars_in_buffer = ch34x_chars_in_buffer,`

In the code, these two function returned `int` values, while the kernel now handles `unsigned int` values.

In this pull request the return type has been changes and the return values has been modified as well.

Also, all trailing spaces at the end of any line have been removed.

This was successfully compiled on Arch Linux, kernel rev: 5.14.3-arch1-1