### PR TITLE
Fix: RTS and DTR should be sent inverted

### DIFF
--- a/ch34x.c
+++ b/ch34x.c
@@ -340,7 +340,7 @@ static int set_control_lines( struct usb_serial *serial,
 {
 	int retval;
 
-	retval = ch34x_vendor_write( VENDOR_MODEM_OUT, (unsigned short)value,
+	retval = ch34x_vendor_write( VENDOR_MODEM_OUT, (unsigned short)~value,
 			0x0000, serial, NULL, 0x00 );
 	dbg_ch34x("%s - value=%d, retval=%d", __func__, value, retval );
 


### PR DESCRIPTION
The [driver for CH341 included in the Linux kernel](https://github.com/torvalds/linux/blob/master/drivers/usb/serial/ch341.c) performs such a conversion:
```
static int ch341_set_handshake(struct usb_device *dev, u8 control)
{
	return ch341_control_out(dev, CH341_REQ_MODEM_CTRL, ~control, 0);
}
```

The driver included in the Linux kernel works with RTS and DTR similarly to the Windows driver.
But the original driver from the manufacturer works in a different way, and because of this it's not possible to use esptool.py for flashing ESP32 devices.
