### PR TITLE
Fix for #34: incompatible-pointer-types

### DIFF
--- a/ch34x.c
+++ b/ch34x.c
@@ -397,7 +397,11 @@ static int ch34x_get_baud_rate( unsigned int baud_rate,
 	return 0;
 }
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,1))
+static void ch34x_set_termios( struct tty_struct *tty,
+		struct usb_serial_port *port, const struct ktermios *old_termios )
+{
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(2,6,27))
 static void ch34x_set_termios( struct tty_struct *tty,
 		struct usb_serial_port *port, struct ktermios *old_termios )
 {


### PR DESCRIPTION
This code works for me, tested on chinese Arduino clone with two examples: blink to check if flashing works and ASCIITable to check if serial input is fine, as well. Both work.

I have doubts about is the kernel versioning selector. Somewhere it'll be `const struct ktermios *old_termios` like it is on kernel 6.1.8 and somewhere it'll be `struct ktermios *old_termios`. I was told that the API change was introduced in `v6.0-rc1-28-gf6d47fe5921a`.

The chip itself already works without a DKMS driver on Linux 6.1.8, so I am not sure my PR will help someone.

Signed-off-by: 6r1d <vic.6r1d@gmail.com>